### PR TITLE
build: in CI, use latest released Tutor, not a custom fork

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,8 @@ jobs:
             - name: checkout
               uses: actions/checkout@v2
 
-            # TOOD: just install latest stable tutor from PyPI once:
-            #   * https://github.com/openedx/edx-platform/pull/30449 is merged and built
-            #     into tutor openedx image, and
-            #   * https://github.com/overhangio/tutor/pull/669 is merged and released.
-            - name: install tutor
-              run: pip install git+https://github.com/kdmccormick/tutor.git@kdmccormick/test-course-nightly#egg=tutor
+            - name: install latest tutor
+              run: pip install tutor
 
             - name: disable mfe
               run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,6 @@ jobs:
             - name: install latest tutor
               run: pip install tutor
 
-            - name: disable mfe
-              run: |
-                  tutor plugins disable mfe
-                  tutor config save
-
             - name: tutor local quickstart
               run: tutor local quickstart --non-interactive
 


### PR DESCRIPTION
Close https://github.com/openedx/openedx-test-course/issues/4