### PR TITLE
build: fix tutor provisioning command in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,14 +18,19 @@ jobs:
             - name: install latest tutor
               run: pip install tutor
 
-            - name: tutor local quickstart
-              run: tutor local quickstart --non-interactive
+            - name: disable tutor-mfe
+              run: |
+                  tutor plugins disable mfe
+                  tutor config save
+
+            - name: launch tutor
+              run: tutor local launch --non-interactive
 
             # We need a user to exist, since all libraries need an owner.
             # The Makefile assigns the library to the user named 'admin', so
             # we name create an 'admin' user here.
             - name: create admin user
-              run: tutor local createuser admin admin@example.com --password admin --staff --superuser
+              run: tutor local do createuser admin admin@example.com --password admin --staff --superuser
 
             - name: import course & libraries
               run: make import


### PR DESCRIPTION
As of Olive, these commands:

    tutor local quickstart ...
    tutor local createuser ...

Are now:

    tutor local launch
    tutor local do createuser ...

Furthermore, the tutor-mfe plugin is now enabled by
default (as the Learning MFE is a required part of
the platform as of Olive) so we must explicitly disable
it since we don't install tutor-mfe.