### PR TITLE
Add catalog-info file for release data 

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,15 @@
+# This file records information about this repo. Its use is described in OEP-55:
+# https://open-edx-proposals.readthedocs.io/en/latest/processes/oep-0055-proc-project-maintainers.html
+
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: "openedx-test-course"
+  description: "A test course and libraries for Open edX platform"
+  annotations:
+    openedx.org/arch-interest-groups: ""
+    openedx.org/release: "master"
+spec:
+  owner: group:openedx-unmaintained
+  type: 'library'
+  lifecycle: 'production'

--- a/openedx.yaml
+++ b/openedx.yaml
@@ -1,5 +1,0 @@
-# This file describes this Open edX repo, as described in OEP-2:
-# http://open-edx-proposals.readthedocs.io/en/latest/oeps/oep-0002.html#specification
-
-openedx-release:
-    ref: master


### PR DESCRIPTION
Description:

Add catalog-info.yaml file for release data, as the BTR script has been updated https://github.com/openedx/repo-tools/issues/439 to read the catalog-info.yaml file if it has release data, we are updating the catalog-info file as per https://github.com/openedx/axim-engineering/issues/882